### PR TITLE
Add Docker Compose Version Check for Compatibility with v1.x and v2+

### DIFF
--- a/linux/node.sh
+++ b/linux/node.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
 minning_address=$1
+# Get Docker Compose version
+docker_compose_version=$(docker compose version | awk '{print $4}')
 
-MINNING_ADDRESS=$minning_address docker-compose up -d
+# Check the major version of Docker Compose
+if [[ "$docker_compose_version" =~ ^v2 ]]; then
+    echo "Detected Docker Compose v2. Using the updated command syntax."
+    MINING_ADDRESS=$mining_address docker compose up -d
+else
+    echo "Detected Docker Compose v1. Using the legacy command syntax."
+    MINING_ADDRESS=$mining_address docker-compose up -d
+fi


### PR DESCRIPTION
This update introduces a version check in the script to ensure compatibility with both Docker Compose v1 and v2+. The script now automatically selects the appropriate command based on the detected Docker Compose version:

v1.x: Uses docker-compose
v2 or higher: Uses docker compose
This change helps streamline the process for users running different versions of Docker Compose, improving compatibility and reducing potential errors.